### PR TITLE
Handle obstacle setters

### DIFF
--- a/src/fourmiz/JeuWin.java
+++ b/src/fourmiz/JeuWin.java
@@ -86,10 +86,9 @@ public class JeuWin implements ActionListener,ChangeListener
 		    	 
 				m.chargement(chooser.getSelectedFile().getName());
 				jp.init(m);
-				} catch (Exception e1) {
-				// TODO Auto-generated catch block
-				e1.printStackTrace();
-			}
+                                } catch (Exception e1) {
+                                e1.printStackTrace();
+                        }
 		    }
 		}
 		if (e.getSource().equals(grille)) { // Clic sur la Checkbox

--- a/src/fourmiz/Obstacle.java
+++ b/src/fourmiz/Obstacle.java
@@ -6,17 +6,17 @@ import java.awt.Color;
 public class Obstacle extends Bloc{
 	
 public Obstacle(){
-	possibility=false;
-	couleur=Color.GRAY;
+        possibility=false;
+        couleur=Color.GRAY;
 }
 
 
 public void setfourmis(int fourm) {
-	// TODO Auto-generated method stub
-	
+        throw new UnsupportedOperationException("Cannot place ants on an obstacle");
 }
 
 public void setnourriture (int x)
 {
+        throw new UnsupportedOperationException("Cannot place food on an obstacle");
 }
 }

--- a/src/test/java/fourmiz/ObstacleTest.java
+++ b/src/test/java/fourmiz/ObstacleTest.java
@@ -1,0 +1,25 @@
+package fourmiz;
+
+public class ObstacleTest {
+    public static void main(String[] args) {
+        Obstacle obstacle = new Obstacle();
+
+        boolean threw = false;
+        try {
+            obstacle.setfourmis(1);
+        } catch (UnsupportedOperationException e) {
+            threw = true;
+        }
+        assert threw : "setfourmis should throw UnsupportedOperationException";
+
+        threw = false;
+        try {
+            obstacle.setnourriture(1);
+        } catch (UnsupportedOperationException e) {
+            threw = true;
+        }
+        assert threw : "setnourriture should throw UnsupportedOperationException";
+
+        System.out.println("Obstacle tests passed.");
+    }
+}


### PR DESCRIPTION
## Summary
- Prevent ants or food from being assigned to obstacles by throwing explicit exceptions.
- Remove leftover TODO comment in user interface.
- Add assertion-based test ensuring obstacle setters throw exceptions.

## Testing
- `mkdir -p build/test && javac -d build/test $(find src -name "*.java") && java -ea -cp build/test fourmiz.ObstacleTest`


------
https://chatgpt.com/codex/tasks/task_e_68974fa4ebb883308c9fe7e3322198cd