### PR TITLE
Remove redundant getposs accessor

### DIFF
--- a/src/fourmiz/Bloc.java
+++ b/src/fourmiz/Bloc.java
@@ -48,7 +48,4 @@ abstract class Bloc{
 		if (mvt==false) fourmis--; // Fourmi sort du bloc
 		else fourmis++; // Fourmi entre dans le bloc
 	}
-	public boolean getposs(){
-		return possibility;
-	}
 }


### PR DESCRIPTION
## Summary
- Remove duplicate `getposs` accessor, leaving `getpossibility` as the sole access method for block availability

## Testing
- `javac -d build $(find src -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_68974fac59088330937b6acc357cd675